### PR TITLE
Improve OperationNode simplification

### DIFF
--- a/src/main/java/ca/wolfram/beta/symath/operations/AddNode.java
+++ b/src/main/java/ca/wolfram/beta/symath/operations/AddNode.java
@@ -43,11 +43,15 @@ public class AddNode extends OperationNode {
     }
 
     @Override
-    public boolean simplify() {
+    void operationSimplify() {
         long constant = simplify(0, 0L);
         if (constant != 0L)
             getChildren().add(BaseNode.create(constant));
-        return super.simplify();
+    }
+
+    @Override
+    void sort() {
+        //TODO
     }
 
     /**
@@ -84,7 +88,7 @@ public class AddNode extends OperationNode {
     }
 
     @Override
-    public double operationEval(VMap map) {
+    double operationEval(VMap map) {
         return getChildren()
                 .stream()
                 .mapToDouble((n) -> n.eval(map))
@@ -92,7 +96,7 @@ public class AddNode extends OperationNode {
     }
 
     @Override
-    public String toString() {
+    String operationToString() {
         StringBuilder s = new StringBuilder().append("(");
         ListIterator<MathNode> iter = getChildren().listIterator();
         if (iter.hasNext()) s.append(iter.next().toString());

--- a/src/main/java/ca/wolfram/beta/symath/operations/MultiplyNode.java
+++ b/src/main/java/ca/wolfram/beta/symath/operations/MultiplyNode.java
@@ -33,11 +33,15 @@ public class MultiplyNode extends OperationNode {
     }
 
     @Override
-    public boolean simplify() {
+    void operationSimplify() {
         long constant = simplify(0, 1L);
         if (constant != 1L)
             getChildren().add(BaseNode.create(constant));
-        return super.simplify();
+    }
+
+    @Override
+    void sort() {
+        //TODO
     }
 
     /**
@@ -87,7 +91,7 @@ public class MultiplyNode extends OperationNode {
     }
 
     @Override
-    public double operationEval(VMap map) {
+    double operationEval(VMap map) {
         return getChildren()
                 .stream()
                 .mapToDouble((n) -> n.eval(map))
@@ -95,7 +99,7 @@ public class MultiplyNode extends OperationNode {
     }
 
     @Override
-    public String toString() {
+    String operationToString() {
         StringBuilder s = new StringBuilder().append("(");
         ListIterator<MathNode> iter = getChildren().listIterator();
         if (iter.hasNext()) s.append(iter.next().toString());

--- a/src/main/java/ca/wolfram/beta/symath/operations/NegateNode.java
+++ b/src/main/java/ca/wolfram/beta/symath/operations/NegateNode.java
@@ -31,12 +31,22 @@ public class NegateNode extends OperationNode {
     }
 
     @Override
-    public double operationEval(VMap map) {
+    double operationEval(VMap map) {
         return -getChildren().get(0).eval(map);
     }
 
     @Override
-    public String toString() {
+    void operationSimplify() {
+        //TODO is children contains operation node, expand it and bring the negation down?
+    }
+
+    @Override
+    void sort() {
+        // NegateNode only has one child and cannot be sorted
+    }
+
+    @Override
+    String operationToString() {
         return String.format("-%s", getChildren().get(0).toString());
     }
 }

--- a/src/main/java/ca/wolfram/beta/symath/operations/OperationNode.java
+++ b/src/main/java/ca/wolfram/beta/symath/operations/OperationNode.java
@@ -23,28 +23,50 @@ public abstract class OperationNode implements MathNode {
     }
 
     @Override
-    public List<MathNode> getChildren() {
+    public final List<MathNode> getChildren() {
         return children;
     }
 
     @Override
-    public boolean isConstant() {
+    public final boolean isConstant() {
         return isConstant;
     }
 
     @Override
-    public double eval(VMap map) {
+    public final double eval(VMap map) {
         if (children.isEmpty())
             throw new IllegalArgumentException("This operation node has no children");
         return operationEval(map);
     }
 
-    public abstract double operationEval(VMap map);
+    abstract double operationEval(VMap map);
 
     @Override
-    public boolean simplify() {
-        for (MathNode n : children)
-            isConstant &= n.isConstant();
-        return isConstant;
+    public final boolean simplify() {
+        operationSimplify();
+        sort();
+        return isConstant = getChildren().stream().allMatch(MathNode::isConstant);
+    }
+
+    /**
+     * Simplify and flatten operation children
+     */
+    abstract void operationSimplify();
+
+    /**
+     * Sort operation children by defined conventions
+     */
+    abstract void sort();
+
+    /**
+     * Returns the String version of an Operation
+     *
+     * @return operation as a String
+     */
+    abstract String operationToString();
+
+    @Override
+    public final String toString() {
+        return operationToString();
     }
 }

--- a/src/main/java/ca/wolfram/beta/symath/operations/PowerNode.java
+++ b/src/main/java/ca/wolfram/beta/symath/operations/PowerNode.java
@@ -33,9 +33,13 @@ public class PowerNode extends OperationNode {
     }
 
     @Override
-    public boolean simplify() {
+    void operationSimplify() {
         //TODO
-        return super.simplify();
+    }
+
+    @Override
+    void sort() {
+        //TODO
     }
 
     @Override
@@ -44,12 +48,12 @@ public class PowerNode extends OperationNode {
     }
 
     @Override
-    public double operationEval(VMap map) {
+    double operationEval(VMap map) {
         return Math.pow(getChildren().get(0).eval(map), getChildren().get(1).eval(map));
     }
 
     @Override
-    public String toString() {
+    String operationToString() {
         if (MathUtils.isReciprocal(this)) return String.format("(1/%s)", getChildren().get(0).toString());
         return String.format("(%s ^ %s)", getChildren().get(0).toString(), getChildren().get(1).toString());
     }


### PR DESCRIPTION
This PR introduces some abstraction to OperationNode to ensure that all subclasses properly implement simplify()

Most overridden methods are now marked final, and have abstract operation counterparts if they need to be done by the subclass.

Simplify() is now as follows:
1. operationSimplify(), which is the equivalent of the original simplify()
2. sort(), which ensures that node contents can be compared
3. isConstant update, which gets the isConstant() status for the future

Since we are implementing abstraction, toString() is also final and calls operationToString()

Eventually equals() will be implemented to compare the type, child count, and toString() values