### PR TITLE
Initialize comparison logic

### DIFF
--- a/src/main/java/ca/wolfram/beta/symath/MathUtils.java
+++ b/src/main/java/ca/wolfram/beta/symath/MathUtils.java
@@ -35,6 +35,10 @@ public class MathUtils {
         return node.getType() == NodeType.POWER && isConstantInt(node.getChildren().get(1), -1L);
     }
 
+    public static boolean childrenAllBase(MathNode node) {
+        return node.getChildren().parallelStream().allMatch(n -> n.getType().argCount == 0);
+    }
+
     public static void print(String s, Object... o) {
         System.out.println(String.format(Locale.CANADA, s, o));
     }

--- a/src/main/java/ca/wolfram/beta/symath/NodeType.java
+++ b/src/main/java/ca/wolfram/beta/symath/NodeType.java
@@ -12,13 +12,19 @@ import java.util.List;
  */
 public enum NodeType {
 
-    CONSTANT(0), MATH_CONSTANT(0), VARIABLE(0),
-    ADD(-2), NEGATE(1), MULTIPLY(-2), POWER(2);
+    CONSTANT(0), MATH_CONSTANT(0), VARIABLE(0), // The order of the BaseNode types matter; change with caution (see OperationNode sorting)
+    ADD(-2, true), NEGATE(1), MULTIPLY(-2, true), POWER(2);
 
     public final int argCount;
+    public final boolean sortable;
 
     NodeType(int argCount) {
+        this(argCount, false);
+    }
+
+    NodeType(int argCount, boolean sortable) {
         this.argCount = argCount;
+        this.sortable = sortable;
     }
 
     public void validateListSize(List<MathNode> list) {

--- a/src/main/java/ca/wolfram/beta/symath/operations/AddNode.java
+++ b/src/main/java/ca/wolfram/beta/symath/operations/AddNode.java
@@ -6,10 +6,7 @@ import ca.wolfram.beta.symath.NodeType;
 import ca.wolfram.beta.symath.VMap;
 import ca.wolfram.beta.symath.base.BaseNode;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.ListIterator;
+import java.util.*;
 
 /**
  * Node that will sum all of its children
@@ -47,11 +44,6 @@ public class AddNode extends OperationNode {
         long constant = simplify(0, 0L);
         if (constant != 0L)
             getChildren().add(BaseNode.create(constant));
-    }
-
-    @Override
-    void sort() {
-        //TODO
     }
 
     /**
@@ -108,5 +100,19 @@ public class AddNode extends OperationNode {
                 s.append(" + ").append(c.toString());
         }
         return s.append(")").toString();
+    }
+
+    /**
+     * Comparison Order
+     * PowerNodes
+     * Ascending variableNode count in children
+     * Alphabetical comparison for VariableNodes
+     * Constants
+     *
+     * @return comparator
+     */
+    @Override
+    Comparator<MathNode> getComparator() {
+        return super.getComparator(); //TODO
     }
 }

--- a/src/main/java/ca/wolfram/beta/symath/operations/MultiplyNode.java
+++ b/src/main/java/ca/wolfram/beta/symath/operations/MultiplyNode.java
@@ -6,10 +6,7 @@ import ca.wolfram.beta.symath.NodeType;
 import ca.wolfram.beta.symath.VMap;
 import ca.wolfram.beta.symath.base.BaseNode;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.ListIterator;
+import java.util.*;
 
 public class MultiplyNode extends OperationNode {
 
@@ -37,11 +34,6 @@ public class MultiplyNode extends OperationNode {
         long constant = simplify(0, 1L);
         if (constant != 1L)
             getChildren().add(BaseNode.create(constant));
-    }
-
-    @Override
-    void sort() {
-        //TODO
     }
 
     /**
@@ -111,5 +103,19 @@ public class MultiplyNode extends OperationNode {
                 s.append(" * ").append(c.toString());
         }
         return s.append(")").toString();
+    }
+
+    /**
+     * Comparison Order
+     * Constants
+     * PowerNodes
+     * Ascending variableNode count in children
+     * Alphabetical comparison for VariableNodes
+     *
+     * @return comparator
+     */
+    @Override
+    Comparator<MathNode> getComparator() {
+        return super.getComparator(); //TODO
     }
 }

--- a/src/main/java/ca/wolfram/beta/symath/operations/NegateNode.java
+++ b/src/main/java/ca/wolfram/beta/symath/operations/NegateNode.java
@@ -41,12 +41,8 @@ public class NegateNode extends OperationNode {
     }
 
     @Override
-    void sort() {
-        // NegateNode only has one child and cannot be sorted
-    }
-
-    @Override
     String operationToString() {
         return String.format("-%s", getChildren().get(0).toString());
     }
+
 }

--- a/src/main/java/ca/wolfram/beta/symath/operations/OperationNode.java
+++ b/src/main/java/ca/wolfram/beta/symath/operations/OperationNode.java
@@ -1,14 +1,19 @@
 package ca.wolfram.beta.symath.operations;
 
 import ca.wolfram.beta.symath.MathNode;
+import ca.wolfram.beta.symath.NodeType;
 import ca.wolfram.beta.symath.VMap;
 
+import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.function.BiFunction;
 
 public abstract class OperationNode implements MathNode {
 
     private List<MathNode> children;
     private boolean isConstant = true;
+    private static EnumMap<NodeType, Comparator<MathNode>> comparatorMap = new EnumMap<>(NodeType.class);
 
     /**
      * Base constructor for all operations
@@ -44,19 +49,48 @@ public abstract class OperationNode implements MathNode {
     @Override
     public final boolean simplify() {
         operationSimplify();
-        sort();
+        if (getType().sortable)
+            getChildren().sort(getComparator(getType()));
         return isConstant = getChildren().stream().allMatch(MathNode::isConstant);
+    }
+
+    private Comparator<MathNode> getComparator(NodeType type) {
+        if (comparatorMap.containsKey(type)) return comparatorMap.get(type);
+        Comparator<MathNode> comparator = getComparator();
+        comparatorMap.put(type, comparator);
+        return comparator;
+    }
+
+    /**
+     * Comparator retrieval
+     * Will be overridden by nodes that allow sorting
+     *
+     * @return Comparator
+     */
+    Comparator<MathNode> getComparator() {
+        throw new RuntimeException(String.format("getComparator() not yet implemented for %s", getType().getName()));
+    }
+
+    /**
+     * Helper function to compare two MathNodes
+     * Applies match conditions both in order and in reverse order
+     *
+     * @param n1      first node
+     * @param n2      second node
+     * @param match   filter to see if comparison is valid
+     * @param compare to retrieve comparison
+     * @return comparison value if matched; null otherwise
+     */
+    Integer compare(MathNode n1, MathNode n2, BiFunction<MathNode, MathNode, Boolean> match, BiFunction<MathNode, MathNode, Integer> compare) {
+        if (match.apply(n1, n2)) return compare.apply(n1, n2);
+        if (match.apply(n2, n1)) return -compare.apply(n2, n1);
+        return null;
     }
 
     /**
      * Simplify and flatten operation children
      */
     abstract void operationSimplify();
-
-    /**
-     * Sort operation children by defined conventions
-     */
-    abstract void sort();
 
     /**
      * Returns the String version of an Operation

--- a/src/main/java/ca/wolfram/beta/symath/operations/PowerNode.java
+++ b/src/main/java/ca/wolfram/beta/symath/operations/PowerNode.java
@@ -38,11 +38,6 @@ public class PowerNode extends OperationNode {
     }
 
     @Override
-    void sort() {
-        //TODO
-    }
-
-    @Override
     public NodeType getType() {
         return NodeType.POWER;
     }


### PR DESCRIPTION
Changes are as follows:

NodeType now has a sortable boolean which is false by default.

After simplification, if getType().sortable is true, OperationNode will retrieve a comparator and sort the children. The comparators are held in a static map so they aren't recreated every time.

By default, getting a comparator will throw an exception. I don't think we need abstraction since most types aren't comparable and test builds will catch it when we don't implement it.

There is also a compare helper method to match conditions and their respective values.